### PR TITLE
(GH-9) Enable use as a hugo module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gethugothemes/bookworm-light
+
+go 1.17


### PR DESCRIPTION
This PR does the minimal work to make the bookworm theme a functional hugo module by adding the go.mod file.

Resolves #9 