### PR TITLE
Make author param of a page optional for single user blogs

### DIFF
--- a/layouts/_default/post.html
+++ b/layouts/_default/post.html
@@ -6,6 +6,7 @@
   {{end}}
   <div class="card-body">
     <ul class="card-meta list-inline mb-2">
+      {{ if .Params.Author }}
       <li class="list-inline-item mb-2">
         {{ with site.GetPage (.Params.Author | urlize | lower) }}
         <a href="{{.Permalink}}" class="card-meta-author">
@@ -18,6 +19,7 @@
         </a>
         {{ end }}
       </li>
+      {{ end }}
       <li class="list-inline-item mb-2">
         <span>{{.PublishDate.Format "02 Jan, 2006"}}</span>
       </li>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,6 +11,7 @@
           <h3 class="h2 mb-4 post-title">{{.Title}}</h3>
           <ul class="card-meta list-inline">
             <li class="list-inline-item">
+              {{ if .Params.author }}
               <a href="#!" class="card-meta-author">
                 {{ with .Site.GetPage (.Params.author | urlize | lower) }}
                 <a href="{{.Permalink}}" class="card-meta-author">
@@ -19,6 +20,9 @@
                 </a>
                 {{ end }}
               </a>
+              {{ else }}
+                <span>{{.Site.Params.Author}}</span>
+              {{ end }}
             </li>
             <li class="list-inline-item">|</li>
             <li class="list-inline-item">
@@ -49,55 +53,58 @@
           </ul>
         </div>
         <div class="col-lg-5 col-md-6 text-center text-md-right mt-4 mt-md-0">
-
           {{- partial "post-share.html" . -}}
         </div>
       </div>
     </div>
 
-    <div class="single-post-author">
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="media d-block d-sm-flex text-center text-sm-left">
-            {{ with .Site.GetPage (.Params.Author | urlize | lower) }}
-            <a href="{{.Permalink}}">
-              {{ partial "image.html" (dict "Src" .Params.image "Size" "150x150" "Class" "img-fluid rounded-circle mr-0 mr-sm-4 mb-4" "Alt" .Title) }}
-            </a>
-            <div class="media-body">
-              <p class="font-primary mb-1">Written By</p>
-              <h4><a href="{{.Permalink}}" class="text-dark font-weight-700">{{.Title}}</a></h4>
-              <p class="font-primary">{{ .Summary | truncate 250 }}</p>
-              <ul class="social-links list-unstyled list-inline ml-0 ml-sm-n2">
-                {{ range .Params.social }}
-                <li class="list-inline-item"><a href="{{.link | safeURL}}">
-                    <i class="lab {{.icon}}"></i>
-                  </a></li>
-                {{end}}
-              </ul>
+    {{ if .Params.Author }}
+      <div class="single-post-author">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <div class="media d-block d-sm-flex text-center text-sm-left">
+              {{ with .Site.GetPage (.Params.Author | urlize | lower) }}
+              <a href="{{.Permalink}}">
+                {{ partial "image.html" (dict "Src" .Params.image "Size" "150x150" "Class" "img-fluid rounded-circle mr-0 mr-sm-4 mb-4" "Alt" .Title) }}
+              </a>
+              <div class="media-body">
+                <p class="font-primary mb-1">Written By</p>
+                <h4><a href="{{.Permalink}}" class="text-dark font-weight-700">{{.Title}}</a></h4>
+                <p class="font-primary">{{ .Summary | truncate 250 }}</p>
+                <ul class="social-links list-unstyled list-inline ml-0 ml-sm-n2">
+                  {{ range .Params.social }}
+                  <li class="list-inline-item"><a href="{{.link | safeURL}}">
+                      <i class="lab {{.icon}}"></i>
+                    </a></li>
+                  {{end}}
+                </ul>
+              </div>
+              {{ end }}
             </div>
-            {{ end }}
           </div>
         </div>
       </div>
-    </div>
+    {{ end }}
 
-    <div class="single-post-similer">
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="row mt-3">
-            <div class="col-12">
-              <h3 class="text-dark font-weight-800 mb-4 pb-2">You May Also Like</h3>
+    {{ $related := (where site.RegularPages "Section" "blog") | intersect (where site.Pages ".Title" "!=" .Title) | union (site.RegularPages.Related . ) }}
+    {{ if $related }}
+      <div class="single-post-similer">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <div class="row mt-3">
+              <div class="col-12">
+                <h3 class="text-dark font-weight-800 mb-4 pb-2">You May Also Like</h3>
+              </div>            
+                {{ range first 2 $related }}
+              <div class="col-md-6">
+                {{ .Render "post" }}
+              </div>
+              {{ end }}
             </div>
-            {{ $related := (where site.RegularPages "Section" "blog") | intersect (where site.Pages ".Title" "!=" .Title) | union (site.RegularPages.Related . ) }}
-              {{ range first 2 $related }}
-            <div class="col-md-6">
-              {{ .Render "post" }}
-            </div>
-            {{ end }}
           </div>
         </div>
       </div>
-    </div>
+    {{ end }}
   </div>
 </section>
 


### PR DESCRIPTION
Hi,

this PR allows the theme to be used without an "explicit author management". 

So you could still use it as before (having multiple authors, dedicated author pages and specify a posts author as `.Params.Author`), but you could also ignore all of that and just rely on the global `Params.Author`.

What do you think about this? 